### PR TITLE
Fix repository name typo: inventoy → inventory

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -116,7 +116,7 @@ jobs:
             fi
             
             # Remove docs/ prefix from config if present
-            sed -i 's|baseurl: "/inventoy-management-ui"|baseurl: "/inventoy-management-ui"|g' _config.yml || true
+            sed -i 's|baseurl: "/inventory-management-ui"|baseurl: "/inventory-management-ui"|g' _config.yml || true
           fi
           
           # Ensure _posts directory exists

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,7 +4,7 @@ title: Inventory Management UI
 description: A modern Vue.js 3 application for inventory management
 
 url: https://metanull.github.io
-baseurl: /inventoy-management-ui
+baseurl: /inventory-management-ui
 
 # Logo and favicon
 logo: "/assets/images/logo.png"
@@ -28,9 +28,9 @@ search:
 nav_sort: case_insensitive
 nav_external_links:
   - title: GitHub Repository
-    url: https://github.com/metanull/inventoy-management-ui
+    url: https://github.com/metanull/inventory-management-ui
   - title: API Documentation
-    url: https://github.com/metanull/inventoy-management-ui
+    url: https://github.com/metanull/inventory-management-ui
 
 # Footer
 footer_content: "Copyright &copy; 2025 Metanull. Made with ❤️ using Vue.js 3 and TypeScript."
@@ -46,7 +46,7 @@ last_edit_time_format: "%b %e %Y at %I:%M %p"
 # GitHub
 gh_edit_link: true
 gh_edit_link_text: "Edit this page on GitHub"
-gh_edit_repository: "https://github.com/metanull/inventoy-management-ui"
+gh_edit_repository: "https://github.com/metanull/inventory-management-ui"
 gh_edit_branch: "main"
 gh_edit_source: docs
 gh_edit_view_mode: "tree"
@@ -93,4 +93,4 @@ sass:
 # Custom CSS
 aux_links:
   "View on GitHub":
-    - "https://github.com/metanull/inventoy-management-ui"
+    - "https://github.com/metanull/inventory-management-ui"


### PR DESCRIPTION
## 🐛 Bug Fix

This PR corrects a typo in the repository name from 'inventoy-management-ui' to 'inventory-management-ui' across all configuration files.

### Changes Made
- ✅ Fixed repository name in GitHub workflow .github/workflows/deploy-pages.yml
- ✅ Updated Jekyll _config.yml with correct repository URLs
- ✅ Corrected baseurl path in configuration files

### Files Modified
- .github/workflows/deploy-pages.yml - Updated sed command and GitHub repository references
- docs/_config.yml - Fixed baseurl, repository URLs, and navigation links

### Impact
- GitHub Pages deployment will now use the correct repository path
- Documentation links will point to the correct repository
- Jekyll site baseurl will be properly configured

This is a straightforward typo fix with no functional changes to the application logic.